### PR TITLE
numba-cuda v0.22.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,4 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes
+# Disabling Python 3.14 builds due to the following error:
+# numba_cuda/numba/cuda/cext/_dispatcher.cpp:1050:2: error: #error "Python minor version is not supported."
+# build_env_vars:
+#   ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,40 +1,55 @@
 {% set name = "numba-cuda" %}
-{% set version = "0.15.2" %}
+{% set version = "0.22.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/numba_cuda-{{ version }}.tar.gz
-  sha256: a5bca48ace64a9456cf8a9c3dadddda23766cdd04276e2ab002a4c623506b8b2
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace("-", "_") }}-{{ version }}.tar.gz
+  sha256: 8688dd21120ab326c703a1319296a5d889f7db3f17a45e5ac9e22126bb359191
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
   skip: true  # [py<39]
+  skip: true  # [osx]
 
 requirements:
+  build:
+    - {{ stdlib('c') }}
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
   host:
     - python
     - setuptools
-    - wheel
     - pip
+    - numpy >=2.1.0
   run:
     - python
-    - numba >=0.59.1
+    - numpy >=1.22
+    - numba >=0.60.0
+    - cuda-bindings >=12.9.1,<14.0.0
+    - cuda-core >=0.3.2,<1.0.0
+    - cuda-version >=12
+    - cuda-nvcc-impl
+    - cuda-cudart-dev
+    # - cuda-nvrtc
+    # - libnvjitlink
+    # - cuda-cccl
+    # - cuda-nvvm
 
 test:
+  requires:
+    - pip
   imports:
     - numba_cuda
   commands:
     - pip check
-  requires:
-    - pip
 
 about:
   home: https://github.com/NVIDIA/numba-cuda
-  summary: CUDA target for Numba
+  summary: A CUDA target for Numba
   description: |
     A Numba target for compiling Python code to excute on CUDA GPUs.
   license: BSD-2-Clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,13 +31,10 @@ requirements:
     - numba >=0.60.0
     - cuda-bindings >=12.9.1,<14.0.0
     - cuda-core >=0.3.2,<1.0.0
+    # Please see PKG-9812 for discussion about the CUDA dependencies.
     - cuda-version >=12
     - cuda-nvcc-impl
     - cuda-cudart-dev
-    # - cuda-nvrtc
-    # - libnvjitlink
-    # - cuda-cccl
-    # - cuda-nvvm
 
 test:
   requires:


### PR DESCRIPTION
numba-cuda 0.22.1

**Destination channel:** defaults

### Links

- [PKG-9812](https://anaconda.atlassian.net/browse/PKG-9812) 
- [Upstream repository]( https://github.com/NVIDIA/numba-cuda)
- [Upstream changelog/diff](https://github.com/NVIDIA/numba-cuda/releases/tag/v0.22.1)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/cuda-python-feedstock/pull/3

### Explanation of changes:

- Sync with CF recipe (v1 -> v0 port)
- Bump version to 0.22.1
- py314 is not supported by upstream, so disabling it


[PKG-9812]: https://anaconda.atlassian.net/browse/PKG-9812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ