### PR TITLE
numba-cuda v0.26.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace("-", "_") }}-{{ version }}.tar.gz
+  url: https://github.com/NVIDIA/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
   sha256: 1dbd58f4af25c984c067437872b211c7b7091807fa76fae1d37b41d982ae3d2e
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "numba-cuda" %}
-{% set version = "0.23.0" %}
+{% set version = "0.26.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace("-", "_") }}-{{ version }}.tar.gz
-  sha256: b991cdedaf40b39232d701abf8949e6a4ae93083e1f55f4c9a3aa25e7557cd6c
+  sha256: 1dbd58f4af25c984c067437872b211c7b7091807fa76fae1d37b41d982ae3d2e
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,10 +27,11 @@ requirements:
     - numpy {{ numpy }}
   run:
     - python
+    - packaging
     - numpy >=1.22
     - numba >=0.60.0
     - cuda-bindings >=12.9.1,<14.0.0
-    - cuda-core >=0.3.2,<1.0.0
+    - cuda-core >=0.5.1,<1.0.0
     # Please see PKG-9812 for discussion about the CUDA dependencies.
     - cuda-version >=12
     - cuda-nvcc-impl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,7 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
-  skip: true  # [py<39]
-  skip: true  # [osx]
+  skip: true  # [py<39 or osx]
 
 requirements:
   build:


### PR DESCRIPTION
numba-cuda 0.26.0

**Destination channel:** defaults

### Links

- [PKG-12259](https://anaconda.atlassian.net/browse/PKG-12259) 
- [Upstream repository](https://github.com/NVIDIA/numba-cuda/tree/v0.26.0)
- [Upstream changelog/diff](https://github.com/NVIDIA/numba-cuda/releases/tag/v0.26.0)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/cuda-core-feedstock/pull/6

### Explanation of changes:

- Version bump
- Dependency updates


[PKG-12259]: https://anaconda.atlassian.net/browse/PKG-12259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ